### PR TITLE
feat: 支持直接运行玩法地图工程

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ## 功能概览
 
 - 一键生成并启动开发测试世界，自动挂载用户行为包 / 资源包。
+- 支持直接运行玩法地图工程，自动识别包含 `level.dat` 的地图目录，并保留地图自带的世界数据和包清单。
 - 支持 Python Mod 热更新，修改代码后回到游戏前台自动触发增量刷新。
 - 支持 JSON UI 热重载，可在资源包 `ui/*.json` 变化后触发原生 `Ctrl+R` UI definition reload。
 - 支持 Shader / Material 单文件热更新，可在资源包文件变化后回到游戏前台触发增量重载。
@@ -133,12 +134,14 @@ MCDEV配置文件，若不存在字段将以此处默认值为基准。
     "game_executable_path": "",
     // 生成的世界种子 若为null则随机生成(null / int)
     "world_seed": null,
-    // 是否在启动时重置并新生成世界
+    // 是否在启动时重置并新生成世界（玩法地图开发建议开启，详见下文）
     "reset_world": false,
     // 用于渲染的世界名称 (string)
     "world_name": "MC_DEV_WORLD",
     // 目录存档名(ASCII STRING)
     "world_folder_name": "MC_DEV_WORLD",
+    // 玩法地图源目录："auto" 会识别当前目录；空字符串表示不启用
+    "world_source_path": "auto",
     // 是否自动进入游戏存档
     "auto_join_game": true,
     // 是否附加调试MOD(boolean)，若启用将在生成的世界中包含热更新脚本(R键触发检测)并重定向输出流使其附加[Python]前缀可供筛选搜索。
@@ -237,6 +240,14 @@ MCDEV配置文件，若不存在字段将以此处默认值为基准。
     }
 }
 ```
+
+## 玩法地图工程
+
+`world_source_path` 默认为 `"auto"`，会识别当前目录中包含 `level.dat` 的地图，未找到时继续按普通 Addon 工程运行。地图位于子目录时需要显式指定路径；设置为空字符串或 `null` 可关闭地图识别。
+
+地图数据会复制到 `world_folder_name` 指定的运行时世界，带有标准 `manifest.json` 的行为包和资源包会通过目录联接加载并参与热更新。
+
+地图开发建议启用 `reset_world`，使每次启动都重新部署地图；否则项目地图的最新内容不会同步到运行时世界。需要保留游戏内测试进度时可临时关闭。
 
 ## MCP客户端配置
 

--- a/include/mcdevtool/env.h
+++ b/include/mcdevtool/env.h
@@ -29,6 +29,8 @@ namespace MCDevTool {
     void cleanRuntimeResourcePacks();
     // 同时清理双pack目录
     void cleanRuntimePacks();
+    // 创建目录联接；如果 link 路径已存在，会先删除原路径。
+    bool createDirectoryJunction(const std::filesystem::path& target, const std::filesystem::path& link);
     // 分析并link源代码pack目录到运行时行为/资源包目录(如果成功将返回有效的PackInfo)
     Addon::PackInfo linkSourcePackToRuntimePack(const std::filesystem::path& sourceDir);
     // 分析并link源代码addon目录到运行时行为包目录 该版本支持批量处理目录下的所有pack

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -25,7 +25,7 @@ static std::vector<std::string> WIN32_GET_ALL_DRIVES() {
 }
 
 // 软链接目录
-static bool CREATE_JUNCTION(const std::filesystem::path& target, const std::filesystem::path& link) {
+bool MCDevTool::createDirectoryJunction(const std::filesystem::path& target, const std::filesystem::path& link) {
 
     std::filesystem::create_directories(link.parent_path());
     if (std::filesystem::exists(link)) {
@@ -92,7 +92,9 @@ static bool CREATE_JUNCTION(const std::filesystem::path& target, const std::file
 }
 
 #else
-static bool CREATE_JUNCTION(const std::filesystem::path& target, const std::filesystem::path& link) = delete
+bool MCDevTool::createDirectoryJunction(const std::filesystem::path&, const std::filesystem::path&) {
+    return false;
+}
 #endif
 
 static void normalizeUUIDString(std::string& uuidStr) {
@@ -238,7 +240,7 @@ namespace MCDevTool {
             auto uuid = info.uuid;
             normalizeUUIDString(uuid);
             auto destPath = getBehaviorPacksPath() / uuid;
-            if (!CREATE_JUNCTION(sourceDir, destPath)) {
+            if (!createDirectoryJunction(sourceDir, destPath)) {
                 std::cerr << "行为包软链接创建失败: " << Utils::pathToUtf8(sourceDir.filename()) << "\n";
             } else {
                 info.path = destPath;
@@ -247,7 +249,7 @@ namespace MCDevTool {
             auto uuid = info.uuid;
             normalizeUUIDString(uuid);
             auto destPath = getResourcePacksPath() / uuid;
-            if (!CREATE_JUNCTION(sourceDir, destPath)) {
+            if (!createDirectoryJunction(sourceDir, destPath)) {
                 std::cerr << "资源包软链接创建失败: " << Utils::pathToUtf8(sourceDir.filename()) << "\n";
             } else {
                 info.path = destPath;

--- a/tools/mcdk/main.cpp
+++ b/tools/mcdk/main.cpp
@@ -35,6 +35,7 @@
 #include "modules/shader_reload_support.hpp"
 #include "modules/material_reload_support.hpp"
 #include "modules/particle_reload_support.hpp"
+#include "modules/world_project.hpp"
 
 
 // mcdevtool api
@@ -940,15 +941,25 @@ static void startGame(const nlohmann::json& config) {
 
     auto modDirConfigs =
         UserModDirConfig::parseListFromJson(config.value("included_mod_dirs", nlohmann::json::array({"./"})));
+    const auto worldSourcePath        = mcdk::resolveWorldSourcePath(config);
+    auto       hotReloadModDirConfigs = modDirConfigs;
+    std::vector<MCDevTool::Addon::PackInfo> worldPacks;
+    if (worldSourcePath) {
+        // 地图源目录只加入热更新列表，不参与原有 Addon 扫描和全局链接。
+        worldPacks = mcdk::collectWorldPacks(*worldSourcePath);
+        mcdk::appendWorldHotReloadModDir(hotReloadModDirConfigs, *worldSourcePath);
+        std::cout << "[MCDK] World Source " << MCDevTool::Utils::pathToGenericUtf8(*worldSourcePath)
+                  << "  Packs=" << worldPacks.size() << "\n";
+    }
 
     if (_isSubprocessMode) {
         // 子进程模式 直接启动游戏exe（通常由vsc插件多开使用）
-        launchGameExe(gameExePath, "", config, &modDirConfigs);
+        launchGameExe(gameExePath, "", config, &hotReloadModDirConfigs, &worldPacks);
         return;
     }
     std::vector<MCDevTool::Addon::PackInfo> linkedPacks;
     if (config.value("include_debug_mod", true)) {
-        auto debugMod = mcdk::registerDebugMod(config, modDirConfigs);
+        auto debugMod = mcdk::registerDebugMod(config, hotReloadModDirConfigs);
         std::cout << "[MCDK] Addons\n";
         std::cout << "  Debug    UUID=" << debugMod.uuid << "\n";
         linkedPacks.push_back(std::move(debugMod));
@@ -957,11 +968,19 @@ static void startGame(const nlohmann::json& config) {
         std::cout << "[MCDK] Addons\n";
         mcdk::linkUserConfigModDirs(modDirConfigs, linkedPacks);
     }
+    // 地图包只补充热更新所需的源码路径，不参与全局链接或世界包清单合并。
+    auto hotReloadPacks = mcdk::makeHotReloadPacks(linkedPacks, worldPacks);
     // 创建世界
     auto worldFolderName = config.value("world_folder_name", "MC_DEV_WORLD");
     auto resetWorld      = config.value("reset_world", false); // 若启用该参数 每次都会强制覆盖世界
     auto worldsPath      = MCDevTool::getMinecraftWorldsPath() / std::filesystem::u8path(worldFolderName);
-    if (!std::filesystem::is_directory(worldsPath) || resetWorld) {
+    if (worldSourcePath) {
+        // 玩法地图使用源码世界作为初始数据，并在后续启动中保留运行时进度。
+        const bool deployed = mcdk::deployWorldSource(*worldSourcePath, worldsPath, resetWorld);
+        if (deployed) {
+            std::cout << "已从玩法地图源码部署运行时世界数据。\n";
+        }
+    } else if (!std::filesystem::is_directory(worldsPath) || resetWorld) {
         std::filesystem::remove_all(worldsPath);
         if (resetWorld) {
             std::cout << "已删除旧世界数据，正在创建新世界...\n";
@@ -984,20 +1003,6 @@ static void startGame(const nlohmann::json& config) {
     }
 
     // netease_world_behavior_packs.json / netease_world_resource_packs.json
-    auto behPacksManifest = nlohmann::json::array();
-    auto resPacksManifest = nlohmann::json::array();
-    for (const auto& pack : linkedPacks) {
-        nlohmann::json packEntry{
-            {"pack_id", pack.uuid},
-            {"version", nlohmann::json::parse(pack.version)},
-        };
-        if (pack.type == MCDevTool::Addon::PackType::BEHAVIOR) {
-            behPacksManifest.push_back(std::move(packEntry));
-        } else if (pack.type == MCDevTool::Addon::PackType::RESOURCE) {
-            resPacksManifest.push_back(std::move(packEntry));
-        }
-    }
-
     auto autoJoinGame = config.value("auto_join_game", true);
     auto envAutoJoin  = mcdk::getEnvAutoJoinGameState();
     if (envAutoJoin != -1) {
@@ -1011,6 +1016,21 @@ static void startGame(const nlohmann::json& config) {
         targetBehJson = "world_behavior_packs.json";
         targetResJson = "world_resource_packs.json";
     }
+    auto behPacksManifest = worldSourcePath
+                              ? mcdk::loadWorldPackManifest(
+                                    *worldSourcePath,
+                                    MCDevTool::Addon::PackType::BEHAVIOR,
+                                    targetBehJson
+                                )
+                              : nlohmann::json::array();
+    auto resPacksManifest = worldSourcePath
+                              ? mcdk::loadWorldPackManifest(
+                                    *worldSourcePath,
+                                    MCDevTool::Addon::PackType::RESOURCE,
+                                    targetResJson
+                                )
+                              : nlohmann::json::array();
+    mcdk::mergeLinkedPacksIntoManifest(behPacksManifest, resPacksManifest, linkedPacks);
     std::ofstream behManifestFile(worldsPath / targetBehJson);
     behManifestFile << behPacksManifest.dump(4);
     behManifestFile.close();
@@ -1025,8 +1045,8 @@ static void startGame(const nlohmann::json& config) {
             gameExePath,
             "",
             config,
-            &modDirConfigs,
-            &linkedPacks
+            &hotReloadModDirConfigs,
+            &hotReloadPacks
         );
         return;
     }
@@ -1078,8 +1098,8 @@ static void startGame(const nlohmann::json& config) {
         gameExePath,
         MCDevTool::Utils::pathToGenericUtf8(configPath),
         config,
-        &modDirConfigs,
-        &linkedPacks
+        &hotReloadModDirConfigs,
+        &hotReloadPacks
     );
 }
 

--- a/tools/mcdk/modules/config.hpp
+++ b/tools/mcdk/modules/config.hpp
@@ -39,6 +39,8 @@ namespace mcdk {
             {          "world_name",                "MC_DEV_WORLD"},
             // 世界文件夹名称
             {   "world_folder_name",                "MC_DEV_WORLD"},
+            // 玩法地图源目录；设为 auto 时自动识别当前工作目录
+            {   "world_source_path",                        "auto"},
             // 是否自动进入游戏存档
             {      "auto_join_game",                          true},
             // 包含调试模组(提供R键热更新以及py输出流标记)

--- a/tools/mcdk/modules/world_project.hpp
+++ b/tools/mcdk/modules/world_project.hpp
@@ -1,0 +1,289 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <mcdevtool/addon.h>
+#include <mcdevtool/env.h>
+#include <mcdevtool/utils.h>
+#include <nlohmann/json.hpp>
+
+#include "mod_dir_config.hpp"
+
+namespace mcdk {
+    namespace fs = std::filesystem;
+
+    inline fs::path normalizeAbsolutePath(const fs::path& path) {
+        std::error_code ec;
+        auto            canonicalPath = fs::weakly_canonical(path, ec);
+        if (!ec) {
+            return canonicalPath.lexically_normal();
+        }
+        return fs::absolute(path).lexically_normal();
+    }
+
+    inline bool isSamePath(const fs::path& left, const fs::path& right) {
+        std::error_code ec;
+        if (fs::exists(left, ec) && !ec && fs::exists(right, ec) && !ec) {
+            if (fs::equivalent(left, right, ec) && !ec) {
+                return true;
+            }
+        }
+        return normalizeAbsolutePath(left) == normalizeAbsolutePath(right);
+    }
+
+    inline bool isWorldProjectDirectory(const fs::path& path) {
+        std::error_code ec;
+        return fs::is_directory(path, ec) && fs::is_regular_file(path / "level.dat", ec);
+    }
+
+    // 解析玩法地图源目录。配置为 auto 时，仅检查当前工作目录。
+    inline std::optional<fs::path>
+    resolveWorldSourcePath(const nlohmann::json& config, const fs::path& workingDirectory = fs::current_path()) {
+        const auto setting = config.find("world_source_path");
+        if (setting != config.end()
+            && (setting->is_null() || (setting->is_string() && setting->get<std::string>().empty()))) {
+            return std::nullopt;
+        }
+
+        if (setting == config.end() || (setting->is_string() && setting->get<std::string>() == "auto")) {
+            if (isWorldProjectDirectory(workingDirectory)) {
+                return normalizeAbsolutePath(workingDirectory);
+            }
+            return std::nullopt;
+        }
+        if (!setting->is_string()) {
+            throw std::runtime_error("world_source_path 必须为路径字符串、auto 或 null。");
+        }
+
+        auto sourcePath = fs::u8path(setting->get<std::string>());
+        if (sourcePath.is_relative()) {
+            sourcePath = workingDirectory / sourcePath;
+        }
+        sourcePath = normalizeAbsolutePath(sourcePath);
+        if (!isWorldProjectDirectory(sourcePath)) {
+            throw std::runtime_error(
+                "玩法地图目录无效（必须包含 level.dat）：" + MCDevTool::Utils::pathToGenericUtf8(sourcePath)
+            );
+        }
+        return sourcePath;
+    }
+
+    inline std::vector<MCDevTool::Addon::PackInfo> collectWorldPacks(const fs::path& worldSourcePath) {
+        std::vector<MCDevTool::Addon::PackInfo> packs;
+        const std::array                       packContainerNames{"behavior_packs", "resource_packs"};
+        for (const auto* containerName : packContainerNames) {
+            const auto      containerPath = worldSourcePath / containerName;
+            std::error_code ec;
+            if (!fs::is_directory(containerPath, ec)) {
+                continue;
+            }
+            for (const auto& entry : fs::directory_iterator(containerPath)) {
+                if (!entry.is_directory()) {
+                    continue;
+                }
+                auto pack = MCDevTool::Addon::parsePackInfo(entry.path());
+                if (pack) {
+                    const auto packPath = normalizeAbsolutePath(entry.path());
+                    pack.path           = packPath;
+                    pack.srcPath        = packPath;
+                    packs.push_back(std::move(pack));
+                }
+            }
+        }
+        return packs;
+    }
+
+    inline void
+    appendWorldHotReloadModDir(std::vector<UserModDirConfig>& configs, const fs::path& worldSourcePath) {
+        const bool alreadyWatched = std::ranges::any_of(configs, [&worldSourcePath](const UserModDirConfig& config) {
+            return config.hotReload && isSamePath(config.getAbsolutePath(), worldSourcePath);
+        });
+        if (!alreadyWatched) {
+            configs.emplace_back(worldSourcePath, true, true);
+        }
+    }
+
+    inline std::vector<MCDevTool::Addon::PackInfo> makeHotReloadPacks(
+        const std::vector<MCDevTool::Addon::PackInfo>& linkedPacks,
+        const std::vector<MCDevTool::Addon::PackInfo>& worldPacks
+    ) {
+        auto hotReloadPacks = linkedPacks;
+        for (const auto& worldPack : worldPacks) {
+            const bool alreadyWatched = std::ranges::any_of(hotReloadPacks, [&worldPack](const auto& pack) {
+                return !pack.srcPath.empty() && isSamePath(pack.srcPath, worldPack.srcPath);
+            });
+            if (!alreadyWatched) {
+                hotReloadPacks.push_back(worldPack);
+            }
+        }
+        return hotReloadPacks;
+    }
+
+    inline bool shouldSkipWorldSourceEntry(const fs::path& sourceEntry) {
+        const auto name = MCDevTool::Utils::pathToUtf8(sourceEntry.filename());
+        // 跳过地图根目录的隐藏元数据，不递归过滤行为包或资源包中的内容。
+        return !name.empty() && name.front() == '.';
+    }
+
+    inline void copyWorldEntry(const fs::path& source, const fs::path& target) {
+        std::error_code ec;
+        const auto      status = fs::symlink_status(source, ec);
+        if (ec) {
+            return;
+        }
+        // 必须先判断链接，避免目录和文件检查跟随链接目标后进入错误分支。
+        if (fs::is_symlink(status)) {
+            fs::create_directories(target.parent_path());
+            fs::copy(source, target, fs::copy_options::copy_symlinks | fs::copy_options::overwrite_existing);
+            return;
+        }
+        if (fs::is_directory(status)) {
+            fs::create_directories(target);
+            for (const auto& entry : fs::directory_iterator(source)) {
+                copyWorldEntry(entry.path(), target / entry.path().filename());
+            }
+            return;
+        }
+        if (fs::is_regular_file(status)) {
+            fs::create_directories(target.parent_path());
+            fs::copy_file(source, target, fs::copy_options::overwrite_existing);
+        }
+    }
+
+    inline void copyWorldPackContainer(const fs::path& source, const fs::path& target) {
+        fs::create_directories(target);
+        for (const auto& entry : fs::directory_iterator(source)) {
+            const auto targetEntry = target / entry.path().filename();
+            if (entry.is_directory() && MCDevTool::Addon::parsePackInfo(entry.path())) {
+                if (!MCDevTool::createDirectoryJunction(entry.path(), targetEntry)) {
+                    std::error_code ec;
+                    fs::remove_all(targetEntry, ec);
+                    copyWorldEntry(entry.path(), targetEntry);
+                    std::cerr << "玩法地图包目录链接创建失败，已回退为复制："
+                              << MCDevTool::Utils::pathToUtf8(entry.path().filename()) << "\n";
+                }
+                continue;
+            }
+            copyWorldEntry(entry.path(), targetEntry);
+        }
+    }
+
+    inline void copyWorldSource(const fs::path& source, const fs::path& target) {
+        fs::create_directories(target);
+        for (const auto& entry : fs::directory_iterator(source)) {
+            if (shouldSkipWorldSourceEntry(entry.path())) {
+                continue;
+            }
+            const auto targetEntry = target / entry.path().filename();
+            const auto name        = MCDevTool::Utils::pathToUtf8(entry.path().filename());
+            if (entry.is_directory() && (name == "behavior_packs" || name == "resource_packs")) {
+                copyWorldPackContainer(entry.path(), targetEntry);
+            } else {
+                copyWorldEntry(entry.path(), targetEntry);
+            }
+        }
+    }
+
+    // 返回 true 表示本次从源码地图重新部署了世界数据。
+    inline bool deployWorldSource(const fs::path& sourcePath, const fs::path& worldPath, bool resetWorld) {
+        if (isSamePath(sourcePath, worldPath)) {
+            throw std::runtime_error("玩法地图源目录不能与运行时世界目录相同。");
+        }
+        const bool worldPathExists = fs::exists(worldPath);
+        if (!resetWorld && worldPathExists && isWorldProjectDirectory(worldPath)) {
+            return false;
+        }
+
+        std::error_code ec;
+        fs::remove_all(worldPath, ec);
+        if (ec) {
+            throw std::runtime_error("无法清理旧的运行时世界目录：" + MCDevTool::Utils::pathToGenericUtf8(worldPath));
+        }
+        copyWorldSource(sourcePath, worldPath);
+        if (!isWorldProjectDirectory(worldPath)) {
+            throw std::runtime_error("玩法地图部署失败：运行时世界缺少 level.dat。");
+        }
+        return true;
+    }
+
+    inline std::string asciiLower(std::string value) {
+        std::ranges::transform(value, value.begin(), [](unsigned char ch) {
+            if (ch >= 'A' && ch <= 'Z') {
+                return static_cast<char>(ch + ('a' - 'A'));
+            }
+            return static_cast<char>(ch);
+        });
+        return value;
+    }
+
+    inline bool samePackId(const nlohmann::json& entry, std::string_view packId) {
+        return entry.is_object() && asciiLower(entry.value("pack_id", "")) == asciiLower(std::string(packId));
+    }
+
+    inline nlohmann::json readPackManifestArray(const fs::path& path) {
+        if (!fs::is_regular_file(path)) {
+            return nlohmann::json::array();
+        }
+        std::ifstream input(path, std::ios::binary);
+        auto          result = nlohmann::json::parse(input, nullptr, false, true);
+        return result.is_array() ? result : nlohmann::json::array();
+    }
+
+    inline nlohmann::json loadWorldPackManifest(
+        const fs::path&            worldSourcePath,
+        MCDevTool::Addon::PackType packType,
+        std::string_view           preferredFileName
+    ) {
+        const std::string standardName = packType == MCDevTool::Addon::PackType::BEHAVIOR ? "world_behavior_packs.json"
+                                                                                          : "world_resource_packs.json";
+        const std::string neteaseName  = packType == MCDevTool::Addon::PackType::BEHAVIOR
+                                           ? "netease_world_behavior_packs.json"
+                                           : "netease_world_resource_packs.json";
+        const auto preferredPath = worldSourcePath / std::string(preferredFileName);
+        if (fs::is_regular_file(preferredPath)) {
+            return readPackManifestArray(preferredPath);
+        }
+
+        // 优先使用当前启动模式对应的清单；文件不存在时才回退到另一种命名。
+        const auto& fallbackName = preferredFileName == standardName ? neteaseName : standardName;
+        return readPackManifestArray(worldSourcePath / fallbackName);
+    }
+
+    inline void mergeLinkedPacksIntoManifest(
+        nlohmann::json&                                behaviorManifest,
+        nlohmann::json&                                resourceManifest,
+        const std::vector<MCDevTool::Addon::PackInfo>& linkedPacks
+    ) {
+        for (const auto& pack : linkedPacks) {
+            auto* manifest = pack.type == MCDevTool::Addon::PackType::BEHAVIOR ? &behaviorManifest
+                           : pack.type == MCDevTool::Addon::PackType::RESOURCE ? &resourceManifest
+                                                                               : nullptr;
+            if (manifest == nullptr) {
+                continue;
+            }
+            const auto version = nlohmann::json::parse(pack.version, nullptr, false);
+            if (!version.is_array()) {
+                throw std::runtime_error("Addon 版本格式无效：" + pack.name);
+            }
+            const auto existing = std::ranges::find_if(*manifest, [&pack](const nlohmann::json& entry) {
+                return samePackId(entry, pack.uuid);
+            });
+            if (existing != manifest->end()) {
+                (*existing)["version"] = version;
+            } else {
+                manifest->push_back({{"pack_id", pack.uuid}, {"version", version}});
+            }
+        }
+    }
+
+} // namespace mcdk


### PR DESCRIPTION
## 改动内容

- 新增 `world_source_path`，默认为"auto"，识别当前目录中包含 `level.dat` 的地图；未找到时继续原有 Addon 流程。支持显式指定地图路径，空字符串或 `null` 可关闭地图识别。
- 将地图数据部署到运行时世界，并通过目录联接加载带有标准 `manifest.json` 的地图包。
- 保留地图原有包清单，并与调试包及 `included_mod_dirs` 中的包合并。
- 地图包接入现有热更新监视。
- 补充玩法地图配置及 `reset_world` 使用说明。

## 需要注意
- `reset_world: false` 会复用已有运行时世界，不判断地图来源；切换地图时需要启用重置或更换 `world_folder_name`。否则使用的还是之前地图的数据
- 为复用原有实现，新增了公共的目录联接创建接口。

已在本地使用模组和地图进行过测试