### PR TITLE
fix(mcdk): sync test world version with selected client

### DIFF
--- a/include/mcdevtool/level.h
+++ b/include/mcdevtool/level.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <vector>
 #include <string_view>
 #include <cstdint>
@@ -6,6 +7,8 @@
 #include <filesystem>
 
 namespace MCDevTool::Level {
+    using ClientVersion = std::array<int32_t, 3>;
+
     // 实验性功能选项
     struct ExperimentsOptions {
         bool enable                     = false;
@@ -36,6 +39,11 @@ namespace MCDevTool::Level {
         bool                            init = true
     );
 
+    // Synchronize version metadata with the selected Minecraft client. When the
+    // version changes, the stale network protocol is removed so the client can
+    // regenerate it when saving the world.
+    void updateLevelDatVersion(std::vector<uint8_t>& levelDatData, const ClientVersion& clientVersion);
+
     // 创建一个默认存档level.dat数据
     std::vector<uint8_t> createDefaultLevelDat(
         std::string_view    worldName, // 世界名称
@@ -54,6 +62,8 @@ namespace MCDevTool::Level {
         std::optional<std::string_view> worldName,
         const LevelOptions&             options = {}
     );
+
+    void updateLevelDatVersionInFile(const std::filesystem::path& filePath, const ClientVersion& clientVersion);
 
     // 获取level.dat模板
     std::vector<uint8_t>& getLevelDatTemplate();

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -4,6 +4,7 @@
 #include <iterator>
 #include <fstream>
 #include <random>
+#include <sstream>
 #include <nbt/NBT.hpp>
 
 using namespace nbt::literals;
@@ -20,6 +21,36 @@ static int64_t generateRandomSeed() {
 }
 
 namespace MCDevTool::Level {
+    namespace {
+        std::string formatClientVersion(const ClientVersion& version) {
+            std::ostringstream result;
+            result << version[0] << '.' << version[1] << '.' << version[2];
+            return result.str();
+        }
+
+        void writeLevelDatFile(const std::filesystem::path& filePath, const std::vector<uint8_t>& fileData) {
+            std::ofstream outputFile(filePath, std::ios::binary | std::ios::trunc);
+            if (!outputFile) {
+                throw std::runtime_error("无法打开level.dat文件进行写入: " + Utils::pathToUtf8(filePath));
+            }
+            outputFile.write(
+                reinterpret_cast<const char*>(fileData.data()),
+                static_cast<std::streamsize>(fileData.size())
+            );
+            if (!outputFile) {
+                throw std::runtime_error("无法写入level.dat文件: " + Utils::pathToUtf8(filePath));
+            }
+        }
+
+        std::vector<uint8_t> readLevelDatFile(const std::filesystem::path& filePath) {
+            std::ifstream inputFile(filePath, std::ios::binary);
+            if (!inputFile) {
+                throw std::runtime_error("无法打开level.dat文件进行读取: " + Utils::pathToUtf8(filePath));
+            }
+            return {(std::istreambuf_iterator<char>(inputFile)), std::istreambuf_iterator<char>()};
+        }
+    } // namespace
+
     // 更新level.dat数据中的世界选项
     void updateLevelDatWorldData(
         std::vector<uint8_t>&           levelDatData,
@@ -72,16 +103,46 @@ namespace MCDevTool::Level {
             if (compoundTag.items().contains("experiments")) {
                 experimentsTag = compoundTag["experiments"].as<nbt::CompoundTag>();
             }
-            experimentsTag["data_driven_biomes"]          = nbt::ByteTag(options.experimentsOptions.dataDrivenBiomes ? 1 : 0);
-            experimentsTag["upcoming_creator_features"]   = nbt::ByteTag(options.experimentsOptions.upcomingCreatorFeatures ? 1 : 0);
-            experimentsTag["experimental_creator_cameras"] = nbt::ByteTag(options.experimentsOptions.experimentalCreatorCameras ? 1 : 0);
-            experimentsTag["gametest"]                    = nbt::ByteTag(options.experimentsOptions.gametest ? 1 : 0);
-            experimentsTag["deferred_technical_preview"]  = nbt::ByteTag(options.experimentsOptions.deferredTechnicalPreview ? 1 : 0);
+            experimentsTag["data_driven_biomes"] = nbt::ByteTag(options.experimentsOptions.dataDrivenBiomes ? 1 : 0);
+            experimentsTag["upcoming_creator_features"] =
+                nbt::ByteTag(options.experimentsOptions.upcomingCreatorFeatures ? 1 : 0);
+            experimentsTag["experimental_creator_cameras"] =
+                nbt::ByteTag(options.experimentsOptions.experimentalCreatorCameras ? 1 : 0);
+            experimentsTag["gametest"] = nbt::ByteTag(options.experimentsOptions.gametest ? 1 : 0);
+            experimentsTag["deferred_technical_preview"] =
+                nbt::ByteTag(options.experimentsOptions.deferredTechnicalPreview ? 1 : 0);
             compoundTag["experiments"] = std::move(experimentsTag);
         }
         auto release = compoundTag.toBinaryNbtWithHeader();
         // 更新输入数据
         bytes.assign(std::make_move_iterator(release.begin()), std::make_move_iterator(release.end()));
+    }
+
+    void updateLevelDatVersion(std::vector<uint8_t>& levelDatData, const ClientVersion& clientVersion) {
+        auto content        = std::string_view{reinterpret_cast<const char*>(levelDatData.data()), levelDatData.size()};
+        auto compoundTagOpt = nbt::io::parseFromContent(content);
+        if (!compoundTagOpt.has_value()) {
+            throw std::runtime_error("无法解析level.dat数据");
+        }
+
+        auto&      compoundTag    = compoundTagOpt.value();
+        const auto versionText    = formatClientVersion(clientVersion);
+        const auto currentVersion = compoundTag.getString("InventoryVersion");
+        if (currentVersion == nullptr || currentVersion->view() != versionText) {
+            compoundTag.items().erase("NetworkVersion");
+        }
+
+        compoundTag["InventoryVersion"]               = nbt::StringTag(versionText);
+        compoundTag["MinimumCompatibleClientVersion"] = nbt::ListTag{
+            nbt::IntTag(clientVersion[0]),
+            nbt::IntTag(clientVersion[1]),
+            nbt::IntTag(clientVersion[2]),
+            nbt::IntTag(0),
+            nbt::IntTag(0),
+        };
+
+        auto release = compoundTag.toBinaryNbtWithHeader();
+        levelDatData.assign(std::make_move_iterator(release.begin()), std::make_move_iterator(release.end()));
     }
 
     // 创建一个默认存档level.dat数据
@@ -109,24 +170,12 @@ namespace MCDevTool::Level {
 
     // 更新文件level.dat的时间轴并立即保存
     void updateLevelDatLastPlayedInFile(const std::filesystem::path& filePath) {
-        // 读取文件内容
-        std::ifstream inputFile(filePath, std::ios::binary);
-        if (!inputFile) {
-            throw std::runtime_error("无法打开level.dat文件进行读取: " + Utils::pathToUtf8(filePath));
-        }
-        std::vector<uint8_t> fileData((std::istreambuf_iterator<char>(inputFile)), std::istreambuf_iterator<char>());
-        inputFile.close();
+        auto fileData = readLevelDatFile(filePath);
 
         // 更新 LastPlayed 字段
         updateLevelDatLastPlayed(fileData);
 
-        // 写回文件
-        std::ofstream outputFile(filePath, std::ios::binary | std::ios::trunc);
-        if (!outputFile) {
-            throw std::runtime_error("无法打开level.dat文件进行写入: " + Utils::pathToUtf8(filePath));
-        }
-        outputFile.write(reinterpret_cast<const char*>(fileData.data()), fileData.size());
-        outputFile.close();
+        writeLevelDatFile(filePath, fileData);
     }
 
     // 更新文件level.dat的世界数据选项并立即保存
@@ -135,24 +184,18 @@ namespace MCDevTool::Level {
         std::optional<std::string_view> worldName,
         const LevelOptions&             options
     ) {
-        // 读取文件内容
-        std::ifstream inputFile(filePath, std::ios::binary);
-        if (!inputFile) {
-            throw std::runtime_error("无法打开level.dat文件进行读取: " + Utils::pathToUtf8(filePath));
-        }
-        std::vector<uint8_t> fileData((std::istreambuf_iterator<char>(inputFile)), std::istreambuf_iterator<char>());
-        inputFile.close();
+        auto fileData = readLevelDatFile(filePath);
 
         // 更新世界数据选项
         updateLevelDatWorldData(fileData, worldName, options, false);
 
-        // 写回文件
-        std::ofstream outputFile(filePath, std::ios::binary | std::ios::trunc);
-        if (!outputFile) {
-            throw std::runtime_error("无法打开level.dat文件进行写入: " + Utils::pathToUtf8(filePath));
-        }
-        outputFile.write(reinterpret_cast<const char*>(fileData.data()), fileData.size());
-        outputFile.close();
+        writeLevelDatFile(filePath, fileData);
+    }
+
+    void updateLevelDatVersionInFile(const std::filesystem::path& filePath, const ClientVersion& clientVersion) {
+        auto fileData = readLevelDatFile(filePath);
+        updateLevelDatVersion(fileData, clientVersion);
+        writeLevelDatFile(filePath, fileData);
     }
 
     // 获取level.dat模板

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,11 @@ target_compile_features(game_environment_test PRIVATE cxx_std_23)
 target_link_libraries(game_environment_test PRIVATE mcdk_core)
 add_test(NAME game-environment COMMAND game_environment_test)
 
+add_executable(level_version_test level_version_test.cpp)
+target_compile_features(level_version_test PRIVATE cxx_std_23)
+target_link_libraries(level_version_test PRIVATE mcdk_core)
+add_test(NAME level-version COMMAND level_version_test)
+
 add_executable(rpc_registry_test rpc_registry_test.cpp)
 target_compile_features(rpc_registry_test PRIVATE cxx_std_23)
 target_link_libraries(rpc_registry_test PRIVATE mcdk_core)

--- a/tests/level_version_test.cpp
+++ b/tests/level_version_test.cpp
@@ -1,0 +1,84 @@
+#include <mcdk/level.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mcdevtool/level.h>
+#include <nbt/NBT.hpp>
+
+namespace {
+    void require(bool condition, const char* message) {
+        if (!condition) {
+            throw std::runtime_error(message);
+        }
+    }
+
+    nbt::CompoundTag parseLevel(const std::vector<uint8_t>& bytes) {
+        const auto content = std::string_view{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+        auto       level   = nbt::io::parseFromContent(content);
+        require(level.has_value(), "Generated level.dat could not be parsed.");
+        return std::move(*level);
+    }
+} // namespace
+
+int main() {
+    const auto uniqueId = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto root =
+        std::filesystem::temp_directory_path() / ("mcdevtool-level-version-test-" + std::to_string(uniqueId));
+    std::filesystem::create_directories(root / "data/behavior_packs/vanilla");
+
+    const auto executable = root / "Minecraft.Windows.exe";
+    std::ofstream(executable).put('\0');
+    {
+        std::ofstream manifest(root / "data/behavior_packs/vanilla/manifest.json");
+        manifest << R"({"header":{"min_engine_version":[1,21,120]}})";
+    }
+
+    const auto version = mcdk::readClientVersion(executable);
+    require(version == MCDevTool::Level::ClientVersion{1, 21, 120}, "Client version was parsed incorrectly.");
+
+    mcdk::WorldProjectConfig config;
+    config.name = "Version Test";
+    auto level  = mcdk::createUserLevel(config, version);
+    auto tag    = parseLevel(level);
+
+    require(!tag.contains("NetworkVersion"), "Stale NetworkVersion was retained.");
+    require(tag.getString("InventoryVersion") != nullptr, "InventoryVersion is missing.");
+    require(tag.getString("InventoryVersion")->view() == "1.21.120", "InventoryVersion is incorrect.");
+
+    const auto minimum = tag.getList("MinimumCompatibleClientVersion");
+    require(minimum != nullptr && minimum->size() == 5, "MinimumCompatibleClientVersion is malformed.");
+    const int expected[] = {1, 21, 120, 0, 0};
+    for (std::size_t index = 0; index < minimum->size(); ++index) {
+        require(
+            minimum->at(index).getType() == nbt::Tag::Type::Int
+                && minimum->at(index).as<nbt::IntTag>().storage() == expected[index],
+            "MinimumCompatibleClientVersion contains an incorrect value."
+        );
+    }
+
+    tag["NetworkVersion"]   = nbt::IntTag(860);
+    const auto serialized   = tag.toBinaryNbtWithHeader();
+    auto       currentLevel = std::vector<uint8_t>(serialized.begin(), serialized.end());
+    MCDevTool::Level::updateLevelDatVersion(currentLevel, version);
+    require(parseLevel(currentLevel).getInt("NetworkVersion") != nullptr, "Current NetworkVersion was removed.");
+
+    {
+        std::ofstream manifest(root / "data/behavior_packs/vanilla/manifest.json", std::ios::trunc);
+        manifest << R"({"header":{"min_engine_version":[1,"21",120]}})";
+    }
+    bool rejectedInvalidVersion = false;
+    try {
+        (void)mcdk::readClientVersion(executable);
+    } catch (const std::runtime_error&) {
+        rejectedInvalidVersion = true;
+    }
+    require(rejectedInvalidVersion, "Invalid client version was accepted.");
+
+    std::filesystem::remove_all(root);
+    return 0;
+}

--- a/tools/mcdk/include/mcdk/level.hpp
+++ b/tools/mcdk/include/mcdk/level.hpp
@@ -1,12 +1,17 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
 #include <vector>
 
+#include <mcdevtool/level.h>
 #include <mcdk/settings.hpp>
 
 namespace mcdk {
 
-    [[nodiscard]] std::vector<uint8_t> createUserLevel(const WorldProjectConfig& config);
+    [[nodiscard]] MCDevTool::Level::ClientVersion readClientVersion(const std::filesystem::path& gameExecutablePath);
+
+    [[nodiscard]] std::vector<uint8_t>
+    createUserLevel(const WorldProjectConfig& config, const MCDevTool::Level::ClientVersion& clientVersion);
 
 } // namespace mcdk

--- a/tools/mcdk/src/application.cpp
+++ b/tools/mcdk/src/application.cpp
@@ -34,6 +34,7 @@ void mcdk::startGame(const UserConfig& config) {
             throw std::runtime_error("未能找到有效的游戏exe文件。");
         }
     }
+    const auto clientVersion = mcdk::readClientVersion(gameExePath);
 
     auto _isSubprocessMode = mcdk::getEnvIsSubprocessMode();
 
@@ -88,7 +89,7 @@ void mcdk::startGame(const UserConfig& config) {
         }
         std::filesystem::create_directories(worldsPath);
         std::ofstream levelFile(worldsPath / "level.dat", std::ios::binary);
-        auto          levelDat = mcdk::createUserLevel(config.world);
+        auto          levelDat = mcdk::createUserLevel(config.world, clientVersion);
         levelFile.write(reinterpret_cast<const char*>(levelDat.data()), levelDat.size());
         levelFile.close();
     } else {
@@ -101,6 +102,7 @@ void mcdk::startGame(const UserConfig& config) {
             MCDevTool::Level::updateLevelDatLastPlayedInFile(worldsPath / "level.dat");
         }
     }
+    MCDevTool::Level::updateLevelDatVersionInFile(worldsPath / "level.dat", clientVersion);
 
     // netease_world_behavior_packs.json / netease_world_resource_packs.json
     auto autoJoinGame = config.world.autoJoin;

--- a/tools/mcdk/src/level.cpp
+++ b/tools/mcdk/src/level.cpp
@@ -1,11 +1,58 @@
 #include <mcdk/level.hpp>
 
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
 #include <mcdevtool/level.h>
+#include <mcdevtool/utils.h>
+#include <nlohmann/json.hpp>
 
 namespace mcdk {
 
-    std::vector<uint8_t> createUserLevel(const WorldProjectConfig& config) {
-        return MCDevTool::Level::createDefaultLevelDat(config.name, config.level);
+    MCDevTool::Level::ClientVersion readClientVersion(const std::filesystem::path& gameExecutablePath) {
+        const auto    manifestPath = gameExecutablePath.parent_path() / "data/behavior_packs/vanilla/manifest.json";
+        std::ifstream manifestFile(manifestPath, std::ios::binary);
+        if (!manifestFile) {
+            throw std::runtime_error("无法读取客户端原版行为包版本: " + MCDevTool::Utils::pathToUtf8(manifestPath));
+        }
+
+        const auto manifest = nlohmann::json::parse(manifestFile, nullptr, false, true);
+        if (manifest.is_discarded()) {
+            throw std::runtime_error(
+                "客户端原版行为包manifest.json格式无效: " + MCDevTool::Utils::pathToUtf8(manifestPath)
+            );
+        }
+
+        const auto header = manifest.find("header");
+        if (header == manifest.end() || !header->is_object()) {
+            throw std::runtime_error("客户端原版行为包manifest.json缺少header");
+        }
+        const auto version = header->find("min_engine_version");
+        if (version == header->end() || !version->is_array() || version->size() != 3) {
+            throw std::runtime_error("客户端原版行为包manifest.json中的min_engine_version必须包含3个整数");
+        }
+
+        MCDevTool::Level::ClientVersion result{};
+        for (std::size_t index = 0; index < result.size(); ++index) {
+            if (!(*version)[index].is_number_integer()) {
+                throw std::runtime_error("客户端原版行为包manifest.json中的min_engine_version必须包含3个整数");
+            }
+            const auto value = (*version)[index].get<int64_t>();
+            if (value < 0 || value > std::numeric_limits<int32_t>::max()) {
+                throw std::runtime_error("客户端原版行为包manifest.json中的min_engine_version超出有效范围");
+            }
+            result[index] = static_cast<int32_t>(value);
+        }
+        return result;
+    }
+
+    std::vector<uint8_t>
+    createUserLevel(const WorldProjectConfig& config, const MCDevTool::Level::ClientVersion& clientVersion) {
+        auto levelDat = MCDevTool::Level::createDefaultLevelDat(config.name, config.level);
+        MCDevTool::Level::updateLevelDatVersion(levelDat, clientVersion);
+        return levelDat;
     }
 
 } // namespace mcdk


### PR DESCRIPTION
mcdk's embedded level.dat template contains stale version metadata (InventoryVersion 1.21.2 and NetworkVersion 686). With the NetEase 3.9 / 1.21.120 client this makes vanilla features fail to register. This change reads min_engine_version from the selected client's vanilla behavior-pack manifest, synchronizes InventoryVersion and MinimumCompatibleClientVersion for new and existing test worlds, and removes NetworkVersion only when the client version changes so the game can regenerate it on save. Added level-version regression coverage. Test: ctest --test-dir build/x86-test -R level-version --output-on-failure (passed).